### PR TITLE
Add Enter key event to textbox

### DIFF
--- a/HumanUI/HumanUI/Components/UI Elements/CreateTextBox_Component.cs
+++ b/HumanUI/HumanUI/Components/UI Elements/CreateTextBox_Component.cs
@@ -22,6 +22,7 @@ namespace HumanUI.Components.UI_Elements
 
         // Set show-label boolean for custom right-click menu
         private bool showLabel;
+        private bool enterEvent;
 
 
         public CreateTextBox_Component()
@@ -37,6 +38,16 @@ namespace HumanUI.Components.UI_Elements
         {
             System.Windows.Forms.ToolStripMenuItem ShowLabelMenuItem = GH_DocumentObject.Menu_AppendItem(menu, "Show Label", new EventHandler(this.Menu_ShowLabelClicked), true, showLabel);
             ShowLabelMenuItem.ToolTipText = "When checked, the UI Element will include the supplied label.";
+
+            System.Windows.Forms.ToolStripMenuItem EnterListenerMenuItem = GH_DocumentObject.Menu_AppendItem(menu, "Use Enter to submit", new EventHandler(this.Menu_EnterEventClicked), true, enterEvent);
+            ShowLabelMenuItem.ToolTipText = "If checked, the text will be submitted when Enter key is pressed.";
+        }
+
+        private void Menu_EnterEventClicked(object sender, EventArgs e)
+        {
+            RecordUndoEvent("Enter Event Toggle");
+            enterEvent = !enterEvent;
+            ExpireSolution(true);
         }
 
         // Method called on click event of Menu Item
@@ -53,6 +64,7 @@ namespace HumanUI.Components.UI_Elements
         public override bool Write(GH_IO.Serialization.GH_IWriter writer)
         {
             writer.SetBoolean("showLabel", showLabel);
+            writer.SetBoolean("enterEvent", enterEvent);
 
             return base.Write(writer);
         }
@@ -61,6 +73,7 @@ namespace HumanUI.Components.UI_Elements
         public override bool Read(GH_IO.Serialization.GH_IReader reader)
         {
             reader.TryGetBoolean("showLabel", ref showLabel);
+            reader.TryGetBoolean("enterEvent", ref enterEvent);
             //updateMessage();
             return base.Read(reader);
         }
@@ -114,7 +127,9 @@ namespace HumanUI.Components.UI_Elements
             //add the label to the stackpanel if showLabel is true
             if (!string.IsNullOrWhiteSpace(label) & showLabel) sp.Children.Add(l);
 
-
+            // save enter event in a textbox tag
+            if (enterEvent)
+                tb.Tag = "enterEvent";
 
             if (includeButton) // if the component is set to use a button for updating, add the button to the stack panel
             {

--- a/HumanUI/HumanUI/Components/UI Elements/CreateTextBox_Component.cs
+++ b/HumanUI/HumanUI/Components/UI Elements/CreateTextBox_Component.cs
@@ -23,6 +23,7 @@ namespace HumanUI.Components.UI_Elements
         // Set show-label boolean for custom right-click menu
         private bool showLabel;
         private bool enterEvent;
+        private bool enterMenuEnabled;
 
 
         public CreateTextBox_Component()
@@ -32,7 +33,7 @@ namespace HumanUI.Components.UI_Elements
         {
             showLabel = true;
         }
-
+                
         // Create right-click menu item for show-label
         protected override void AppendAdditionalComponentMenuItems(System.Windows.Forms.ToolStripDropDown menu)
         {
@@ -41,6 +42,11 @@ namespace HumanUI.Components.UI_Elements
 
             System.Windows.Forms.ToolStripMenuItem EnterListenerMenuItem = GH_DocumentObject.Menu_AppendItem(menu, "Use Enter to submit", new EventHandler(this.Menu_EnterEventClicked), true, enterEvent);
             ShowLabelMenuItem.ToolTipText = "If checked, the text will be submitted when Enter key is pressed.";
+            if (!enterMenuEnabled)
+            {
+                EnterListenerMenuItem.Enabled = false;
+                EnterListenerMenuItem.Checked = true;
+            }
         }
 
         private void Menu_EnterEventClicked(object sender, EventArgs e)
@@ -127,9 +133,7 @@ namespace HumanUI.Components.UI_Elements
             //add the label to the stackpanel if showLabel is true
             if (!string.IsNullOrWhiteSpace(label) & showLabel) sp.Children.Add(l);
 
-            // save enter event in a textbox tag
-            if (enterEvent)
-                tb.Tag = "enterEvent";
+            
 
             if (includeButton) // if the component is set to use a button for updating, add the button to the stack panel
             {
@@ -137,15 +141,25 @@ namespace HumanUI.Components.UI_Elements
                 DockPanel.SetDock(b, Dock.Right);
                 //this key is used by other methods (like AddEvents) to figure out whether or not to listen to all changes or just button presses.
                 sp.Name = "GH_TextBox";
+
+                // disable menu item (enter will still work)
+                enterMenuEnabled = false;
             }
 
             else
             {
                 //this key is used by other methods (like AddEvents) to figure out whether or not to listen to all changes or just button presses.
                 sp.Name = "GH_TextBox_NoButton";
+
+                enterMenuEnabled = true;
             }
+
             tb.HorizontalAlignment = HorizontalAlignment.Stretch;
             sp.Children.Add(tb);
+
+            // save enter event in a textbox tag
+            if (enterEvent || !enterMenuEnabled)
+                tb.Tag = "enterEvent";
 
             //pass out the stackpanel
             DA.SetData("Text Box", new UIElement_Goo(sp, String.Format("TextBox: {0}", label), InstanceGuid, DA.Iteration));

--- a/HumanUI/HumanUI/Components/UI Main/ValueListener_Component.cs
+++ b/HumanUI/HumanUI/Components/UI Main/ValueListener_Component.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -17,6 +17,7 @@ using De.TorstenMandelkow.MetroChart;
 using Grasshopper.Kernel.Parameters;
 using MahApps.Metro.Controls;
 using RangeSlider = MahApps.Metro.Controls.RangeSlider;
+using System.Windows.Input;
 
 namespace HumanUI
 {
@@ -311,6 +312,13 @@ namespace HumanUI
                     TextBox tb = u as TextBox;
                     Panel p = tb.Parent as Panel;
                     List<Button> btns = p.Children.OfType<Button>().ToList<Button>();
+
+                    if (tb.Tag == "enterEvent")
+                    {
+                        tb.KeyDown -= OnTextboxKeyPressed;
+                        tb.KeyDown += OnTextboxKeyPressed;
+                    }
+
                     if (btns.Count > 0)
                     {
                         foreach (Button btn0 in btns)
@@ -319,7 +327,7 @@ namespace HumanUI
                             btn0.Click += ExpireThis;
                         }
                     }
-                    else
+                    else if (tb.Tag != "enterEvent")
                     {
                         tb.TextChanged -= ExpireThis;
                         tb.TextChanged += ExpireThis;
@@ -390,6 +398,11 @@ namespace HumanUI
             }
         }
 
+        private void OnTextboxKeyPressed(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+                ExpireSolution(true);
+        }
 
         void RemoveEvents(UIElement u)
         {


### PR DESCRIPTION
**Background:**
It is very convenient to submit text with the Enter key when writing something to textbox

**Description:**
I added a new right-click menu option to the CreateTextbox component to enable new functionality. It defaults to unchecked to keep the existing behaviour in older scripts.
![EnterToSubmit](https://user-images.githubusercontent.com/7596090/129901180-14334b71-029c-4b98-a0d2-c2281d89fb46.png)

When checked, textbox.Tag property is set to "enterEvent" value. It would be probably more consistent to use sp.Name for this but I was afraid to break some other functionality because it's used in several other places in code. So I decided to stick to Textbox.Tag

In ValueListener component I inserted additional check for that Tag property. If exists it would subscribe to KeyPressed event and would expire solution when Enter is pressed.

It works for both cases: when button is enabled and without it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/andrewheumann/humanui/4)
<!-- Reviewable:end -->
